### PR TITLE
Add retry function. Fixes #48

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,7 @@ class DataLoggerConfig(Schema):
     slave_id = fields.Int(required=False, load_default=1)
     poll_interval = fields.Int(required=False, load_default=60)
     poll_interval_if_off = fields.Int(required=False, load_default=600)
+    poll_retries = fields.Int(required=False, load_default=10)
     http = fields.Nested(HttpConfig(), required=False)
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,7 @@ datalogger:
   slave_id: 1
   poll_interval: 60
   poll_interval_if_off: 600
+  poll_retries: 10
   http:
     enabled: True
     user: admin


### PR DESCRIPTION
Retries will now be done before considering the datalogger to be offline. Introducing new config setting "poll_retries" to set how many retries should be done before the datalogger is considered to be offline. Will retry according to the "poll_interval" config setting.