### PR TITLE
fix(http): strip the datalogger's NUL padding from CGI fields

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -56,6 +56,24 @@ DEBOUNCE_POLLS = 3
 OFFLINE_ZERO = {"power", "current"}
 OFFLINE_UNAVAILABLE = {"voltage", "frequency", "temperature"}
 
+# What the datalogger pads a CGI field with. Captured 2026-08-15: both inverter.cgi
+# and moniter.cgi answer with a fixed 1313 byte buffer holding 33 NUL bytes, then the
+# semicolon separated fields, then NUL again to the end of the buffer. So the first
+# field of a response carries 33 leading NULs and the last one is nothing but padding.
+#
+# The inverter serial arrived that way, 49 characters of which 33 were NUL. It was the
+# only topic affected because inverter_serial is the only sensor in sensors.yaml
+# mapped to field 0 of either response, while its sibling datalogger_serial is
+# moniter.cgi field 2 and came through as a clean 16 characters. An http sensor has no
+# length or field count to get wrong, so there is nothing in the register map to
+# correct here. Removing the padding is the decode.
+#
+# It cannot be left to a consumer. Home Assistant stores the payload verbatim as the
+# sensor state and its recorder then INSERTs it into Postgres, which refuses a NUL in
+# a text column. That fails the flush and poisons the session, so every other row
+# queued in the same commit is discarded along with it.
+HTTP_PADDING = "\x00 \t\r\n\v\f"
+
 
 class App:
     def __init__(self):
@@ -406,8 +424,12 @@ class App:
             logging.error("HTTP endpoints did not return 200")
             return
 
-        ir_registers = ir.text.split(";")
-        mr_registers = mr.text.split(";")
+        # The sensor schema allows no endpoint other than these two, so every sensor
+        # below finds its response here.
+        registers = {
+            "inverter": ir.text.split(";"),
+            "moniter": mr.text.split(";"),
+        }
 
         for sensor in self.sensors_config:
             if (
@@ -418,29 +440,51 @@ class App:
             ):
                 continue
 
-            value = None
+            endpoint = sensor["http"]["endpoint"]
+            register = sensor["http"]["register"]
+            value = self.http_value(registers[endpoint], endpoint, register)
 
-            if (
-                sensor["http"]["endpoint"] == "inverter"
-                and ir_registers[sensor["http"]["register"]]
-            ):
-                value = ir_registers[sensor["http"]["register"]]
-            elif (
-                sensor["http"]["endpoint"] == "moniter"
-                and mr_registers[sensor["http"]["register"]]
-            ):
-                value = mr_registers[sensor["http"]["register"]]
-
-            if value:
-                value = value.strip()
-                logging.info(
-                    f"{sensor['http']['register']} {sensor['description']} : {value}"
-                )
+            if value is not None:
+                logging.info(f"{register} {sensor['description']} : {value}")
                 self.publish(
                     f"{self.config['mqtt']['topic_prefix']}/{sensor['name']}",
                     value,
                     retain=True,
                 )
+
+    def http_value(self, registers, endpoint, register):
+        # One field of a CGI response, or None if it does not carry a usable value.
+        #
+        # An http register is a position in a semicolon separated response, and the
+        # only description of that response is sensors.yaml. A field the datalogger
+        # does not send is therefore a missing reading, not a crash: indexing straight
+        # into the list raised an IndexError that escaped query_http, query_modbus and
+        # main, and took the process down with it.
+        if register >= len(registers):
+            logging.error(
+                f"{endpoint}.cgi returned {len(registers)} fields, so there is no "
+                f"register {register}"
+            )
+            return None
+
+        value = registers[register].strip(HTTP_PADDING)
+
+        if not value:
+            return None
+
+        # Padding at either end is expected and has just been removed. Anything else
+        # unprintable means the field is not the string it is described as, and this
+        # is the one path that puts device supplied text into a payload -- a modbus
+        # reading is a number, or a status string that came from sensors.yaml. Refuse
+        # it loudly rather than publish something a recorder cannot store.
+        if any(character < " " for character in value):
+            logging.error(
+                f"Ignoring {endpoint}.cgi register {register}: {value!r} still holds "
+                "a control character after the padding was stripped"
+            )
+            return None
+
+        return value
 
     def datalogger_is_offline(self, *, offline: bool):
         # Check if new state if offline

--- a/tests/test_http_values.py
+++ b/tests/test_http_values.py
@@ -1,0 +1,175 @@
+"""The datalogger pads its CGI responses with NUL bytes.
+
+Both CGIs answer with a fixed 1313 byte buffer: 33 NUL bytes, then the semicolon
+separated fields, then NUL again to the end of the buffer. So the first field of a
+response carries 33 leading NULs and the last one is padding to the end.
+
+tcpsolis2mqtt/inverter_serial published a 49 character payload of which 33 were NUL.
+Home Assistant stores the payload verbatim and its recorder cannot INSERT a NUL into
+a Postgres text column, which fails the flush and discards every other row queued in
+the same commit.
+
+It was the only topic affected because inverter_serial is the only sensor in
+sensors.yaml mapped to field 0 of either response. That makes it a property of the
+register map rather than of that one sensor, so the fields nothing is mapped to are
+covered here too.
+
+The two responses below are the real ones, captured 2026-08-15 with the inverter
+awake.
+"""
+
+import pytest
+
+import app as app_module
+
+RESPONSE_LENGTH = 1313
+LEADING_PADDING = 33
+
+
+def response(fields):
+    return ("\x00" * LEADING_PADDING + fields).ljust(RESPONSE_LENGTH, "\x00")
+
+
+INVERTER_SERIAL = "1805090232050086"
+DATALOGGER_SERIAL = "7A123208131058AB"
+
+# Fields 0, 1 and 2 are read as inverter_serial, inverter_firmware and inverter_model.
+# Field 2 reads "509" on this hardware, which is what the datalogger's own web UI
+# shows against "Inverter model" -- odd for a model designation, but the label is the
+# vendor's and not this project's invention.
+INVERTER_CGI = response(
+    f"{INVERTER_SERIAL};83003A;509;29.2;240;50.599998;41298;NO;\r\n"
+)
+
+# Read at fields 2, 3, 8, 9, 10 and 11. Field 0 is nothing but the leading padding and
+# field 1 is "3"; no sensor is mapped to either, which is why the padding on this
+# response has never been visible.
+MONITER_CGI = response(
+    f";3;{DATALOGGER_SERIAL};10010125;Disabled;null;null;Enabled;Airthings;24;"
+    "192.168.71.135;92:78:48:DA:27:75;Connected;null;"
+)
+
+
+class Response:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+
+@pytest.fixture
+def http_app(make_app, monkeypatch):
+    """An App polling a stubbed datalogger over HTTP, recording what it publishes."""
+
+    def _make(inverter=INVERTER_CGI, moniter=MONITER_CGI):
+        app = make_app()
+        app.config["datalogger"]["http"] = {
+            "enabled": True,
+            "user": "admin",
+            "password": "123456789",
+        }
+
+        bodies = {"inverter.cgi": inverter, "moniter.cgi": moniter}
+        monkeypatch.setattr(
+            app_module.requests,
+            "get",
+            lambda url, **kwargs: Response(bodies[url.rsplit("/", 1)[-1]]),
+        )
+
+        return app
+
+    return _make
+
+
+def value_of(app, name):
+    return {topic: payload for topic, payload in app.published}.get(
+        f"tcpsolis2mqtt/{name}"
+    )
+
+
+def test_the_captures_are_the_shape_the_datalogger_sends(http_app):
+    # The trace is only worth keeping if it stays the response that was captured.
+    for body in (INVERTER_CGI, MONITER_CGI):
+        assert len(body) == RESPONSE_LENGTH
+        assert len(body) - len(body.lstrip("\x00")) == LEADING_PADDING
+        assert body.endswith("\x00")
+
+    # The symptom, before anything strips it.
+    assert len(INVERTER_CGI.split(";")[0]) == 49
+
+
+def test_the_inverter_serial_is_published_without_its_padding(http_app):
+    app = http_app()
+    app.query_http()
+
+    assert value_of(app, "inverter_serial") == INVERTER_SERIAL
+    assert len(value_of(app, "inverter_serial")) == 16
+
+
+def test_no_published_value_holds_a_nul(http_app):
+    app = http_app()
+    app.query_http()
+
+    for topic, payload in app.published:
+        assert "\x00" not in payload, topic
+
+
+def test_the_fields_that_were_already_clean_are_untouched(http_app):
+    # Stripping must not eat real content, so the siblings that always decoded
+    # correctly are pinned to the byte.
+    app = http_app()
+    app.query_http()
+
+    assert value_of(app, "datalogger_serial") == DATALOGGER_SERIAL
+    assert value_of(app, "inverter_firmware") == "83003A"
+    assert value_of(app, "inverter_model") == "509"
+    assert value_of(app, "datalogger_firmware") == "10010125"
+    assert value_of(app, "wifi_ssid") == "Airthings"
+    assert value_of(app, "wifi_signal") == "24"
+    assert value_of(app, "wifi_ip") == "192.168.71.135"
+    assert value_of(app, "wifi_mac") == "92:78:48:DA:27:75"
+
+
+def test_the_fields_nothing_is_mapped_to_decode_to_nothing(make_app):
+    # The class of defect, rather than the one instance of it. moniter.cgi field 0 is
+    # the leading padding and the last field of either response is the trailing
+    # padding, so a sensor mapped to any of them would publish NULs exactly as
+    # inverter_serial did. None of them is read today, which is why the list of clean
+    # topics looked reassuring.
+    app = make_app()
+
+    moniter = MONITER_CGI.split(";")
+    inverter = INVERTER_CGI.split(";")
+
+    assert app.http_value(moniter, "moniter", 0) is None
+    assert app.http_value(moniter, "moniter", len(moniter) - 1) is None
+    assert app.http_value(inverter, "inverter", len(inverter) - 1) is None
+
+
+def test_a_field_that_is_still_binary_is_refused(http_app):
+    # Padding at the ends is expected. A control character in the middle means the
+    # field is not the string sensors.yaml describes, and publishing it would poison
+    # the recorder exactly as the padding did.
+    app = http_app(inverter=response("18050902\x0032050086;83003A;"))
+    app.query_http()
+
+    assert value_of(app, "inverter_serial") is None
+    assert value_of(app, "inverter_firmware") == "83003A"
+
+
+def test_a_field_the_response_does_not_have_is_skipped(http_app):
+    # sensors.yaml is the only description of these responses, so a shorter one is a
+    # missing reading rather than an IndexError out of query_http, query_modbus and
+    # main.
+    app = http_app(moniter=response(f";3;{DATALOGGER_SERIAL};10010125;"))
+    app.query_http()
+
+    assert value_of(app, "datalogger_serial") == DATALOGGER_SERIAL
+    assert value_of(app, "wifi_mac") is None
+    assert value_of(app, "inverter_serial") == INVERTER_SERIAL
+
+
+def test_nothing_is_published_when_http_is_disabled(make_app):
+    app = make_app()
+    app.query_http()
+
+    assert app.published == []


### PR DESCRIPTION
`tcpsolis2mqtt/inverter_serial` published a 49 character payload: 33 NUL bytes followed by the 16 character serial. Home Assistant stores the payload verbatim and its recorder cannot `INSERT` a NUL into a Postgres text column, so the flush failed and every other row queued in the same commit was discarded with it.

## What the datalogger actually sends

Captured from the device on 2026-08-15, awake:

```
00000000: 0000 0000 ... 0000  (33 NUL bytes)
00000020: 0031 3830 3530 3930 3233 3230 3530 3038  .180509023205008
00000030: 363b 3833 3030 3341 3b35 3039 3b32 392e  6;83003A;509;29.
00000040: 323b 3234 303b 3530 2e35 3939 3939 383b  2;240;50.599998;
00000050: 3431 3239 383b 4e4f 3b0d 0a00 0000 0000  41298;NO;.......
        ... NUL to the end of the buffer
```

Both `inverter.cgi` and `moniter.cgi` answer with a fixed 1313 byte buffer: 33 NUL bytes, the semicolon separated fields, then NUL again to the end. The padding is the head and tail of the response body rather than part of any value, so the first field of a response carries 33 leading NULs and the last is nothing but padding.

That is why `inverter_serial` was the only broken topic — it is the only sensor mapped to field 0 of either response, while its sibling `datalogger_serial` is `moniter.cgi` field 2 and always decoded to a clean 16 characters. An http sensor has no length or field count in its definition, so there was nothing in the register map to correct: removing the padding *is* the decode. The `value.strip()` already there did nothing, since NUL is not whitespace.

## Changes

- Strip the padding in a new `http_value()` helper, and refuse a value that still holds a control character once the padding is off. Three fields carry the same padding and are read by nothing today, so the other topics looking clean was no evidence of health: `moniter.cgi` fields 0 and 1, and the trailing field of both responses. The guard covers those and anything a future register map edit reaches.
- Stop indexing past the end of a short response. That `IndexError` escaped `query_http`, `query_modbus` and `main` and took the process down, when a field the datalogger does not send is only a missing reading.

## Verification

Against the live datalogger, before and after, same response:

```
before:  tcpsolis2mqtt/inverter_serial   len= 49  '\x00...\x001805090232050086'
after:   tcpsolis2mqtt/inverter_serial   len= 16  '1805090232050086'
```

`tests/test_http_values.py` carries both responses as captured. Five of its eight tests fail against the previous code, including the `IndexError`. Full suite 101 passed, `ruff format --check` and `ruff check` clean.

`VERSION` is deliberately left at 3.0.0 — it is bumped with a release, not with a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)