### PR TITLE
fix(http): bound the CGI requests with a timeout

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -74,6 +74,21 @@ OFFLINE_UNAVAILABLE = {"voltage", "frequency", "temperature"}
 # queued in the same commit is discarded along with it.
 HTTP_PADDING = "\x00 \t\r\n\v\f"
 
+# Seconds to wait for the datalogger's CGIs: to answer the connection, then for each
+# block of the body. requests has no default, so without this a datalogger that
+# completes the handshake and then says nothing blocks the poll loop forever.
+#
+# Nothing notices that. Mqtt.loop_start runs paho's network thread, so the broker
+# keeps seeing a live session and the Last Will never fires. Home Assistant sees an
+# app that is up and has simply stopped publishing, and every sensor holds the value
+# it had at the moment we hung -- which is the stale reading docs/energy-guards.md
+# exists to prevent.
+#
+# query_http only runs on the transition back to online, which is the moment the
+# datalogger is least likely to be fully awake and most likely to accept a connection
+# it cannot answer.
+HTTP_TIMEOUT = (5, 10)
+
 
 class App:
     def __init__(self):
@@ -406,6 +421,7 @@ class App:
                     self.config["datalogger"]["http"]["user"],
                     self.config["datalogger"]["http"]["password"],
                 ),
+                timeout=HTTP_TIMEOUT,
             )
 
             mr_url = f"http://{self.config['datalogger']['host']}/moniter.cgi"
@@ -415,6 +431,7 @@ class App:
                     self.config["datalogger"]["http"]["user"],
                     self.config["datalogger"]["http"]["password"],
                 ),
+                timeout=HTTP_TIMEOUT,
             )
         except Exception as e:
             logging.error(f"Unable to poll HTTP endpoints {e}")

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -1,0 +1,82 @@
+"""What happens when the datalogger accepts a CGI connection and then says nothing.
+
+requests has no default timeout, so before HTTP_TIMEOUT existed this hung the poll
+loop for good. Nothing reported it: paho's network thread keeps the broker session
+alive, so the Last Will never fires and Home Assistant sees an app that is up and has
+quietly stopped publishing, every sensor frozen on its last value.
+
+query_http only runs on the transition back to online, so the hang would happen at
+the moment the datalogger is coming back from being flaky.
+"""
+
+import pytest
+
+import app as app_module
+
+
+class Response:
+    def __init__(self, text=";;;;;;;;;;;;;;", status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+
+@pytest.fixture
+def http_app(make_app, monkeypatch):
+    """An App whose CGI requests are recorded, or made to fail on demand."""
+
+    def _make(raises=None):
+        app = make_app()
+        app.config["datalogger"]["http"] = {
+            "enabled": True,
+            "user": "admin",
+            "password": "123456789",
+        }
+
+        app.requests_made = []
+
+        def get(url, **kwargs):
+            app.requests_made.append((url, kwargs))
+            if raises is not None:
+                raise raises
+            return Response()
+
+        monkeypatch.setattr(app_module.requests, "get", get)
+
+        return app
+
+    return _make
+
+
+def test_every_cgi_request_carries_a_timeout(http_app):
+    app = http_app()
+    app.query_http()
+
+    assert len(app.requests_made) == 2, "inverter.cgi and moniter.cgi"
+
+    for url, kwargs in app.requests_made:
+        assert kwargs.get("timeout") == app_module.HTTP_TIMEOUT, url
+
+
+def test_the_timeout_is_a_connect_and_a_read_timeout(http_app):
+    # A single number would only bound the connect. The datalogger's failure is to
+    # accept the connection and then never send the body, which is the read half.
+    connect, read = app_module.HTTP_TIMEOUT
+
+    assert connect > 0 and read > 0
+
+
+def test_a_timeout_is_survived(http_app):
+    app = http_app(raises=app_module.requests.exceptions.Timeout("timed out"))
+
+    app.query_http()
+
+    assert app.published == [], "nothing to publish, and nothing raised"
+
+
+def test_a_timeout_does_not_stop_the_next_poll_trying_again(http_app):
+    app = http_app(raises=app_module.requests.exceptions.Timeout("timed out"))
+
+    app.query_http()
+    app.query_http()
+
+    assert len(app.requests_made) == 2, "one attempt per call, no state left behind"


### PR DESCRIPTION
Closes #166

`requests` has no default timeout, so `query_http` could wait forever. A datalogger that completes the TCP handshake and then never sends a body blocked the poll loop permanently.

Nothing reported it. `Mqtt.loop_start` runs paho's network thread, so the broker kept seeing a live session and the Last Will never fired. Home Assistant saw an app that was up and had simply stopped publishing, every sensor frozen on its last value — a held stale reading, arriving by a route the energy guards do not cover.

`query_http` only runs on the transition back to online, which is the moment the datalogger is least likely to be fully awake and most likely to accept a connection it cannot answer.

`(5, 10)` rather than a single number: a scalar only bounds the connect, and the failure here is the read half.

**Tests** — `tests/test_http_timeout.py`. Two guard against the timeout being dropped again (both fail on `main`); two pin that a timeout is survived and leaves no state behind, which the existing handler already did.

105 passed, ruff format and check clean.