### PR TITLE
fix(modbus): make CHUNK_ATTEMPTS the whole retry budget

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -32,16 +32,17 @@ PERIOD_LENGTH = {"daily": 10, "monthly": 7, "yearly": 4}
 # These two describe the whole retry budget only because the client is built with
 # retries=0. pymodbus runs its own loop, `while count_retries <= retries`, so its
 # stock default of 3 is four attempts per request and multiplies with this one: a
-# chunk that never answered cost 3 x 4 x MODBUS_TIMEOUT, a little over two minutes at
-# the timeout we used to pass, against a poll_interval most people set to 30 or 60.
+# chunk that never answered cost 3 x 4 x MODBUS_TIMEOUT, a little over two minutes,
+# against a poll_interval most people set to 30 or 60.
 # The numbers here have to be the only ones that count, or they are not a budget.
 CHUNK_ATTEMPTS = 3
 CHUNK_RETRY_DELAY = 2
 
-# Seconds to wait for one request to the datalogger. It is a device on the local
-# network answering from a cache, so the 10 this used to be only ever bought a longer
-# wait before the same failure.
-MODBUS_TIMEOUT = 5
+# Seconds to wait for one request to the datalogger. Deliberately left where it has
+# always been: how patient we are with a single answer is the one number here that can
+# turn a poll that used to succeed into one that fails, and it wants measuring against
+# the hardware rather than guessing.
+MODBUS_TIMEOUT = 10
 
 # How many polls a finished period's total has to hold a new value before it is
 # believed. A rollover happens once a day at most and then persists, so a value that

--- a/app/app.py
+++ b/app/app.py
@@ -28,8 +28,20 @@ VERSION = "3.0.0"
 PERIOD_LENGTH = {"daily": 10, "monthly": 7, "yearly": 4}
 
 # How hard to try for one chunk of registers before giving up on the whole poll.
+#
+# These two describe the whole retry budget only because the client is built with
+# retries=0. pymodbus runs its own loop, `while count_retries <= retries`, so its
+# stock default of 3 is four attempts per request and multiplies with this one: a
+# chunk that never answered cost 3 x 4 x MODBUS_TIMEOUT, a little over two minutes at
+# the timeout we used to pass, against a poll_interval most people set to 30 or 60.
+# The numbers here have to be the only ones that count, or they are not a budget.
 CHUNK_ATTEMPTS = 3
 CHUNK_RETRY_DELAY = 2
+
+# Seconds to wait for one request to the datalogger. It is a device on the local
+# network answering from a cache, so the 10 this used to be only ever bought a longer
+# wait before the same failure.
+MODBUS_TIMEOUT = 5
 
 # How many polls a finished period's total has to hold a new value before it is
 # believed. A rollover happens once a day at most and then persists, so a value that
@@ -767,8 +779,9 @@ class App:
             client = ModbusTcpClient(
                 self.config["datalogger"]["host"],
                 port=self.config["datalogger"]["port"],
-                reconnect_delay=10,
-                timeout=10,
+                timeout=MODBUS_TIMEOUT,
+                # One attempt per request. read_chunk owns the retrying.
+                retries=0,
             )
 
             if not client.connect():

--- a/tests/test_modbus_read.py
+++ b/tests/test_modbus_read.py
@@ -63,7 +63,12 @@ def query(make_app, clock, monkeypatch):
         client = StubClient(*answers)
         app = make_app()
         app.get_register_interval()
-        monkeypatch.setattr(app_module, "ModbusTcpClient", lambda *a, **kw: client)
+
+        def build(*args, **kwargs):
+            app.client_kwargs = kwargs
+            return client
+
+        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
         return app, client, app.query_modbus()
 
     return _query
@@ -125,3 +130,28 @@ def test_an_all_zero_response_is_discarded(query):
     app, client, registers = query(Response([0] * SPAN))
 
     assert registers == {}
+
+
+def test_the_client_is_not_allowed_its_own_retry_loop(query):
+    # pymodbus runs `while count_retries <= retries`, so its default of 3 is four
+    # attempts per request. Multiplied by CHUNK_ATTEMPTS that is twelve requests for
+    # one chunk, each waiting the full timeout, and neither constant in this file
+    # says so. read_chunk does the retrying; the client does exactly one attempt.
+    app, _, _ = query()
+
+    assert app.client_kwargs["retries"] == 0
+
+
+def test_the_client_waits_the_timeout_this_module_declares(query):
+    app, _, _ = query()
+
+    assert app.client_kwargs["timeout"] == app_module.MODBUS_TIMEOUT
+
+
+def test_the_client_is_not_given_a_setting_that_does_nothing(query):
+    # reconnect_delay was passed for years. The pymodbus docs are explicit that it is
+    # not used by the sync client, and the client was rebuilt every poll anyway, so
+    # it only ever read as though reconnection were handled somewhere.
+    app, _, _ = query()
+
+    assert "reconnect_delay" not in app.client_kwargs


### PR DESCRIPTION
Closes #167

**The issue understated this.** I read the installed pymodbus source rather than trusting the docs: the loop is `while count_retries <= self.retries`, so the default `retries=3` is **four** attempts per request. The real worst case for a chunk that never answers was 3 × 4 × 10s + 4s ≈ **124 seconds**, against a `poll_interval` of 30. That also rules out `retries=1`, which would still be two attempts.

**Changes**

- `retries=0` on the client — exactly one attempt per request, so `CHUNK_ATTEMPTS` and `CHUNK_RETRY_DELAY` are the only numbers that decide anything. Worst case ~124s → ~34s.
- `reconnect_delay=10` removed. The pymodbus docs state it is not used by the sync client, and the client was rebuilt every poll anyway, so it only ever read as though reconnection were handled somewhere.

**What is deliberately *not* here.** An earlier version of this branch also dropped the timeout from 10 to 5. That is split out. `retries=0` cannot make a read fail that would otherwise have succeeded — it only stops pymodbus multiplying our attempt count behind our back. The timeout decides how patient we are with a single answer, so halving it is the one change that could turn a working poll into a failing one, and there is no measurement behind the 5. It gets its own branch and its own evidence.

**Tests** — nothing simulates a timeout, so wall clock isn't what these pin. The three added cases guard the constructor arguments that decide it, including one that `reconnect_delay` doesn't come back.

104 passed, ruff clean.