### PR TITLE
fix(mqtt): publish the datalogger availability only when it changes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -79,6 +79,10 @@ class App:
     def __init__(self):
         self.datalogger_offline = False
         self.datalogger_unreachable = True
+        # What was last put on the availability topic, so the same answer is not sent
+        # again. None until the first poll decides, which is what makes that first
+        # publish happen whichever way it goes.
+        self.availability_published = None
         self.init_config()
         self.load_sensors_config()
         self.retries_done = 0
@@ -511,11 +515,20 @@ class App:
 
         self.datalogger_offline = offline
 
-        self.publish(
-            f"{self.config['mqtt']['topic_prefix']}/datalogger_availability",
-            OFFLINE if offline else ONLINE,
-            retain=True,
-        )
+        # Only when it changed. A successful poll asserts this once for the connection
+        # and again for every chunk of registers it reads, so the topic was being
+        # rewritten with the answer it already held several thousand times a day. The
+        # message is retained, so saying it once is saying it for good.
+        availability = OFFLINE if offline else ONLINE
+
+        if availability != self.availability_published:
+            self.availability_published = availability
+
+            self.publish(
+                f"{self.config['mqtt']['topic_prefix']}/datalogger_availability",
+                availability,
+                retain=True,
+            )
 
         if self.datalogger_offline:
             logging.info("Datalogger offline")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,7 @@ def make_app(sensors_config):
 
         app.datalogger_offline = False
         app.datalogger_unreachable = True
+        app.availability_published = None
         app.retries_done = 0
         app.register_span_start = 0
         app.register_span_end = 0

--- a/tests/test_offline_behaviour.py
+++ b/tests/test_offline_behaviour.py
@@ -143,3 +143,59 @@ def test_active_power_does_not_depend_on_the_datalogger(make_app, sensors_config
     active_power = next(s for s in sensors_config if s["name"] == "active_power")
 
     assert app.availability_topics(active_power) == ["tcpsolis2mqtt/availability"]
+
+
+def availability_publishes(app):
+    return [
+        payload for topic, payload in app.published if topic == DATALOGGER_AVAILABILITY
+    ]
+
+
+def test_online_is_published_once_however_often_the_poll_asserts_it(make_app):
+    # A successful poll says so once for the connection and again for every chunk of
+    # registers it reads, so at the default chunk size this topic was rewritten with
+    # the answer it already held twice a poll, a few thousand times a day.
+    app = make_app()
+
+    for _ in range(5):
+        app.datalogger_is_offline(offline=False)
+
+    assert availability_publishes(app) == ["online"]
+
+
+def test_the_first_answer_is_always_published(make_app):
+    # Retained, so Home Assistant needs it on the topic once and then never again
+    # until it changes. Nothing has been said at startup, which is what the None
+    # starting value is for.
+    app = make_app()
+    app.retries_done = app.config["datalogger"]["poll_retries"]
+
+    app.datalogger_is_offline(offline=True)
+
+    assert availability_publishes(app) == ["offline"]
+
+
+def test_a_change_is_still_published(make_app):
+    app = make_app()
+    retries = app.config["datalogger"]["poll_retries"]
+
+    app.datalogger_is_offline(offline=False)
+    app.datalogger_is_offline(offline=False)
+
+    # Going offline is not believed until the retries are used up, and coming online
+    # above reset that counter, so it takes poll_retries + 1 of these before the
+    # datalogger is declared offline at all.
+    for _ in range(retries + 1):
+        app.datalogger_is_offline(offline=True)
+
+    app.datalogger_is_offline(offline=False)
+
+    assert availability_publishes(app) == ["online", "offline", "online"]
+
+
+def test_going_offline_still_publishes_what_is_genuinely_zero(offline):
+    # The zeros are not gated by the change check above, and must not be: they go to
+    # the sensor topics, not the availability one.
+    app = offline()
+
+    assert published(app)["active_power"] == 0


### PR DESCRIPTION
Closes #168

`datalogger_is_offline()` published unconditionally, and a successful poll calls it once for the connection and again for every chunk of registers. At the default chunk size that's two identical retained messages per poll — roughly 5,700 a day telling the broker what it already held.

The message is retained, so saying it once says it for good. `availability_published` tracks what was last sent; the publish is skipped when the answer hasn't changed. It starts as `None` rather than `ONLINE` so the first poll publishes whichever way it decides.

Only the availability topic is gated — the zeros published for genuinely-zero sensors while offline go to sensor topics and are untouched.

The offline direction was already effectively guarded, at the call site in `query_modbus` rather than here, which is why this only showed up as repeated `online` messages.

**Tests** — four added to `test_offline_behaviour.py`; two fail on `main`. One of them documents something non-obvious I got wrong first time: going offline isn't believed until `poll_retries` is exhausted, and coming online resets that counter, so it takes `poll_retries + 1` assertions to flip.

105 passed, ruff clean.