### PR TITLE
fix(poll): measure the interval from the start of the poll

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -835,6 +835,25 @@ class App:
     def pick_from_registers(self, registers, start, count):
         return [registers[i] for i in range(start, start + count)]
 
+    def seconds_until_next_poll(self, started):
+        # The interval is the gap between the starts of two polls, not the gap
+        # between the end of one and the start of the next. Sleeping the whole
+        # interval after the work added the length of the poll to every cycle, which
+        # is a second or two normally and much more when a chunk had to be retried:
+        # the poll that gave up on the datalogger took longer than the interval it
+        # was then followed by.
+        #
+        # A poll that overran its own interval is not made up for, it just starts the
+        # next one immediately. Measuring from the start each time means a slow poll
+        # cannot leave a debt behind for the ones after it.
+        interval = (
+            self.config["datalogger"]["poll_interval"]
+            if not self.datalogger_offline
+            else self.config["datalogger"]["poll_interval_if_off"]
+        )
+
+        return max(0, interval - (monotonic() - started))
+
     def main(self):
         # Generate Home assistant MQTT discovery topics
         self.generate_ha_discovery_topics()
@@ -847,6 +866,7 @@ class App:
 
         while True:
             logging.debug("Datalogger scan start at " + datetime.now().isoformat())
+            poll_started = monotonic()
 
             # Reset the counters on the wall clock, the datalogger is unreachable
             # at midnight so this cannot wait for a successful poll
@@ -969,12 +989,10 @@ class App:
                         retain=True,
                     )
 
-            # wait with next poll configured interval, or if datalogger is not responding ten times the interval
-            sleep_duration = (
-                self.config["datalogger"]["poll_interval"]
-                if not self.datalogger_offline
-                else self.config["datalogger"]["poll_interval_if_off"]
-            )
+            # Wait until the next poll is due, which is the configured interval after
+            # this one started, or the longer interval if the datalogger is not
+            # answering.
+            sleep_duration = self.seconds_until_next_poll(poll_started)
 
             logging.debug(f"Datalogger scanning paused for {sleep_duration} seconds")
             sleep(sleep_duration)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,8 @@ def make_app(sensors_config):
                 "host": "192.0.2.1",
                 "port": 502,
                 "device_id": 1,
+                "poll_interval": 30,
+                "poll_interval_if_off": 600,
                 "poll_retries": poll_retries,
                 "register_chunks": register_chunks,
                 "http": {"enabled": False},

--- a/tests/test_poll_interval.py
+++ b/tests/test_poll_interval.py
@@ -1,0 +1,60 @@
+"""When the next poll is due.
+
+The interval is meant to be the gap between the starts of two polls. Sleeping the
+whole interval after the work instead added the length of the poll to every cycle.
+Normally that is a second or two and nobody notices, but a poll that has to retry a
+chunk of registers takes far longer than the interval that follows it, so the cycle
+that most needs to come round again is the one that was delayed most.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def app(make_app, clock):
+    return make_app()
+
+
+def test_a_quick_poll_is_followed_by_the_rest_of_the_interval(app, clock):
+    started = 0
+    clock.advance(2)
+
+    assert app.seconds_until_next_poll(started) == 28
+
+
+def test_an_instant_poll_waits_the_whole_interval(app):
+    assert app.seconds_until_next_poll(0) == 30
+
+
+def test_a_poll_that_overran_starts_the_next_one_immediately(app, clock):
+    # 40 seconds of retrying against a 30 second interval. Before this the app then
+    # slept another 30 on top, making the gap 70.
+    started = 0
+    clock.advance(40)
+
+    assert app.seconds_until_next_poll(started) == 0
+
+
+def test_the_wait_is_never_negative(app, clock):
+    clock.advance(6000)
+
+    assert app.seconds_until_next_poll(0) == 0
+
+
+def test_an_offline_datalogger_gets_the_longer_interval(app, clock):
+    app.datalogger_offline = True
+    clock.advance(10)
+
+    assert app.seconds_until_next_poll(0) == 590
+
+
+def test_a_slow_poll_leaves_no_debt_for_the_next_one(app, clock):
+    # Measured from the start of each poll, not from a running deadline, so one poll
+    # that overran cannot make the following ones fire back to back to catch up.
+    clock.advance(40)
+    assert app.seconds_until_next_poll(0) == 0
+
+    started = clock.now
+    clock.advance(1)
+
+    assert app.seconds_until_next_poll(started) == 29


### PR DESCRIPTION
Closes #169

The sleep came after the work and was the full interval, so the real gap between two polls was the interval *plus* the poll duration. Normally a second or two. The case that matters is the poll that had to retry a chunk — the slowest one, followed by the same full interval as a fast one, so the cycle that most needed to come round again was delayed most.

`seconds_until_next_poll()` subtracts the elapsed time, so `poll_interval` means the gap between two starts.

**One deliberate choice:** measured from the start of each poll, not from a running deadline. A poll that overran starts the next one immediately and leaves no debt, so a slow poll can't make the following ones fire back to back to catch up — against a datalogger that's already struggling, that's the last thing this should do. `test_a_slow_poll_leaves_no_debt_for_the_next_one` pins it.

The calculation moved into a method because `main()` can't be called from a test and this is the part worth pinning. Six tests in a new `test_poll_interval.py`; `conftest` gained the two interval keys it was missing.

107 passed, ruff clean.