### PR TITLE
fix(modbus): do not call the datalogger online just because it accepted a socket

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -824,8 +824,18 @@ class App:
                 self.datalogger_is_offline(offline=True)
             return
 
-        else:
-            self.datalogger_is_offline(offline=False)
+        # A connection that opens says nothing about whether there is a working
+        # datalogger behind it, so nothing is declared here. Every morning while the
+        # inverter wakes up, this one accepts the connection and then refuses to serve
+        # a single register, and saying "online" on the strength of the handshake
+        # reset retries_done on every one of those polls. The counter never reached
+        # poll_retries, the datalogger was never declared offline, and the availability
+        # topic sat at online for as long as the state lasted -- thirteen consecutive
+        # failed polls on the morning of 2026-08-19, about seven minutes, with Home
+        # Assistant holding the voltages and the frequency from before it started.
+        #
+        # The first chunk of registers that actually arrives is what says we are
+        # online, further down the loop below.
 
         registers = {}
         chunk_size = self.config["datalogger"]["register_chunks"]

--- a/tests/test_modbus_read.py
+++ b/tests/test_modbus_read.py
@@ -74,6 +74,29 @@ def query(make_app, clock, monkeypatch):
     return _query
 
 
+@pytest.fixture
+def polls(make_app, clock, monkeypatch):
+    """One App polled repeatedly, so state that carries between polls is visible."""
+
+    def _polls(*rounds):
+        app = make_app()
+        app.get_register_interval()
+        client = StubClient()
+
+        def build(*args, **kwargs):
+            return client
+
+        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
+
+        for answers in rounds:
+            client.answers = list(answers)
+            app.query_modbus()
+
+        return app
+
+    return _polls
+
+
 def test_a_chunk_is_read_once_when_it_answers(query):
     app, client, registers = query(live_response())
 
@@ -155,3 +178,46 @@ def test_the_client_is_not_given_a_setting_that_does_nothing(query):
     app, _, _ = query()
 
     assert "reconnect_delay" not in app.client_kwargs
+
+
+def test_a_connection_that_opens_is_not_proof_the_datalogger_is_there(query):
+    # The morning of 2026-08-19: the datalogger accepted the connection and then
+    # refused every register while the inverter woke up. Announcing online on the
+    # strength of the handshake reset the retry counter on each of those polls.
+    app, client, registers = query()
+
+    assert registers == {}
+    assert app.retries_done == 1, "the failed poll counted"
+
+
+def test_failed_polls_accumulate_towards_offline(polls):
+    # The bug this pins. Thirteen consecutive failures in the real incident, all of
+    # them logged "done 0 of 20 retries", because each poll's successful connect
+    # cleared the count the poll before had added.
+    app = polls((), (), ())
+
+    assert app.retries_done == 3
+
+
+def test_failed_polls_eventually_declare_the_datalogger_offline(polls, make_app):
+    retries = make_app().config["datalogger"]["poll_retries"]
+
+    app = polls(*[()] * (retries + 1))
+
+    assert app.datalogger_offline
+    assert dict(app.published)["tcpsolis2mqtt/datalogger_availability"] == "offline"
+
+
+def test_a_poll_that_reads_registers_says_the_datalogger_is_online(polls):
+    app = polls((live_response(),))
+
+    assert not app.datalogger_offline
+    assert app.retries_done == 0
+    assert dict(app.published)["tcpsolis2mqtt/datalogger_availability"] == "online"
+
+
+def test_reads_that_start_working_again_clear_the_count(polls):
+    app = polls((), (), (live_response(),))
+
+    assert app.retries_done == 0
+    assert not app.datalogger_offline


### PR DESCRIPTION
Closes #179

`query_modbus` declared the datalogger online as soon as `connect()` returned, which reset `retries_done` and cleared `datalogger_unreachable`. The reads that followed then failed and put the counter back up by one — from zero, every time.

That's the state this datalogger is in every morning while the inverter wakes: it accepts the connection and then refuses to serve a single register. On 2026-08-19 that ran for **thirteen consecutive polls**, each logging `done 0 of 20 retries`, the count never moving. So it was never declared offline, the availability topic said `online` for about seven minutes while nothing could be read, and Home Assistant kept treating the grid voltages, frequency and inverter temperature as live — showing the values from before the failures began.

A connection that opens proves nothing about what's behind it. Only a read does. The per-chunk call further down is now the only thing that says online, and it fires once registers have actually arrived.

**Please read this before merging.** The fix makes the counter work; your config decides when it trips. The cluster runs `poll_retries: 20` at a 30 second interval, so it now takes **ten minutes** of failed reads to declare the datalogger offline. This morning's flap lasted about seven — so even with this merged, tomorrow's availability topic would most likely still say `online` throughout it. The counter would be climbing instead of stuck at zero, which is the bug fixed, but the stale-value window closes only if `poll_retries` comes down or the backoff becomes progressive. Worth deciding separately.

**Side effect:** the came-online branch is what runs `query_http`, so this also stops both CGI pages being re-fetched on every failed poll — thirteen times this morning where there should have been one. It does **not** fix what those fetches published; that's #180.

**Tests** — a new `polls` fixture drives several polls against one `App`, since the bug only exists across polls; within a single poll the counter ends at 1 either way. Two of the five fail on `main`:

- `test_failed_polls_accumulate_towards_offline`
- `test_failed_polls_eventually_declare_the_datalogger_offline`

123 passed, ruff clean.