### PR TITLE
fix(http): ignore a CGI response whose every field reads as nothing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -465,6 +465,12 @@ class App:
             "moniter": mr.text.split(";"),
         }
 
+        asleep = {
+            endpoint
+            for endpoint, fields in registers.items()
+            if self.http_response_is_dead(endpoint, fields)
+        }
+
         for sensor in self.sensors_config:
             if (
                 not sensor["active"]
@@ -475,6 +481,10 @@ class App:
                 continue
 
             endpoint = sensor["http"]["endpoint"]
+
+            if endpoint in asleep:
+                continue
+
             register = sensor["http"]["register"]
             value = self.http_value(registers[endpoint], endpoint, register)
 
@@ -519,6 +529,56 @@ class App:
             return None
 
         return value
+
+    def http_registers(self, endpoint):
+        # Which fields of a CGI response this app is set up to read.
+        return [
+            sensor["http"]["register"]
+            for sensor in self.sensors_config
+            if sensor["active"]
+            and "http" in sensor
+            and sensor["http"].get("endpoint") == endpoint
+            and "register" in sensor["http"]
+        ]
+
+    def http_response_is_dead(self, endpoint, fields):
+        # The datalogger is usually up before the inverter is. Its own page answers
+        # properly while inverter.cgi answers with nothing at all: on the morning of
+        # 2026-08-19 the serial came back empty and the firmware and model came back
+        # as "000000" and "0", where awake they read "83003A" and "509". The empty
+        # one was already dropped, but the other two are not empty and went straight
+        # out. query_http only runs when the datalogger comes back, so those two
+        # values were still what Home Assistant was showing hours later, and would
+        # have stood until the next time it went away.
+        #
+        # This is the judgement response_is_dead makes about a block of registers,
+        # for the same reason: a well formed answer in which everything reads as
+        # nothing is not a reading.
+        #
+        # Judged only on the fields this app reads. The rest of the response is
+        # described nowhere, and at least one of them holds "NO" whether the inverter
+        # is awake or not, so it cannot be part of the test.
+        values = [
+            self.http_value(fields, endpoint, register)
+            for register in self.http_registers(endpoint)
+        ]
+        present = [value for value in values if value is not None]
+
+        # Every field empty is not evidence of anything: nothing would be published
+        # from this endpoint either way, and http_value has already said so.
+        if not present:
+            return False
+
+        # "0", "000000" and "0.0" all mean the same nothing. One zero among real
+        # values is a reading -- a wifi signal really can be 0 -- so the whole set
+        # has to read as nothing before the response does.
+        if not all(value.strip("0.") == "" for value in present):
+            return False
+
+        logging.info(
+            f"Ignoring {endpoint}.cgi, every field it is read for is empty or zero"
+        )
+        return True
 
     def datalogger_is_offline(self, *, offline: bool):
         # Check if new state if offline

--- a/tests/test_http_asleep.py
+++ b/tests/test_http_asleep.py
@@ -1,0 +1,129 @@
+"""What the CGIs say while the inverter is still asleep.
+
+The datalogger is usually up before the inverter is. Its own page answers properly;
+the inverter's page answers with nothing.
+
+On the morning of 2026-08-19 the app read inverter.cgi thirteen times between 05:32
+and 05:39 and published `Inverter Firmware : 000000` and `Inverter Model : 0` every
+time, where the awake values are 83003A and 509. The serial came back empty and was
+already dropped, so it kept the good value by luck. The other two are not empty, so
+nothing stopped them, and because query_http only runs when the datalogger comes
+back they were still what Home Assistant was showing hours later.
+
+The awake response below is the one captured on 2026-08-15. The asleep one is
+reconstructed: the log records the three fields the app reads, not the whole body.
+"""
+
+import pytest
+
+import app as app_module
+
+RESPONSE_LENGTH = 1313
+LEADING_PADDING = 33
+
+
+def response(fields):
+    return ("\x00" * LEADING_PADDING + fields).ljust(RESPONSE_LENGTH, "\x00")
+
+
+INVERTER_AWAKE = response(
+    "1805090232050086;83003A;509;29.2;240;50.599998;41298;NO;\r\n"
+)
+
+# Fields 0, 1 and 2 are the ones read, and are what the log proves. "NO" in field 7
+# is the awake value kept deliberately: something in this response is non-zero even
+# when the inverter is asleep, which is why the check cannot look at the whole body.
+INVERTER_ASLEEP = response(";000000;0;0.0;0;0.0;0;NO;\r\n")
+
+MONITER = response(
+    ";3;7A123208131058AB;10010125;Disabled;null;null;Enabled;Airthings;24;"
+    "192.168.71.135;92:78:48:DA:27:75;Connected;null;"
+)
+
+# Field 9 is the wifi signal. A real 0 there must not condemn the whole response.
+MONITER_NO_SIGNAL = response(
+    ";3;7A123208131058AB;10010125;Disabled;null;null;Enabled;Airthings;0;"
+    "192.168.71.135;92:78:48:DA:27:75;Connected;null;"
+)
+
+
+@pytest.fixture
+def http_app(make_app, monkeypatch):
+    def _make(inverter=INVERTER_AWAKE, moniter=MONITER):
+        app = make_app()
+        app.config["datalogger"]["http"] = {
+            "enabled": True,
+            "user": "admin",
+            "password": "123456789",
+        }
+
+        bodies = {"inverter.cgi": inverter, "moniter.cgi": moniter}
+
+        class Response:
+            def __init__(self, text):
+                self.text = text
+                self.status_code = 200
+
+        monkeypatch.setattr(
+            app_module.requests,
+            "get",
+            lambda url, **kwargs: Response(bodies[url.rsplit("/", 1)[-1]]),
+        )
+
+        return app
+
+    return _make
+
+
+def published(app):
+    return {topic.rsplit("/", 1)[-1]: payload for topic, payload in app.published}
+
+
+def test_an_awake_inverter_publishes_what_it_says(http_app):
+    app = http_app()
+    app.query_http()
+
+    assert published(app)["inverter_firmware"] == "83003A"
+    assert published(app)["inverter_model"] == "509"
+
+
+def test_an_asleep_inverter_publishes_nothing_at_all(http_app):
+    # The regression. "000000" and "0" used to go straight out and stand all day.
+    app = http_app(inverter=INVERTER_ASLEEP)
+    app.query_http()
+
+    assert "inverter_firmware" not in published(app)
+    assert "inverter_model" not in published(app)
+    assert "inverter_serial" not in published(app)
+
+
+def test_the_dataloggers_own_page_is_judged_separately(http_app):
+    # It was answering correctly all through that morning, and there is no reason to
+    # lose the wifi and datalogger sensors because the inverter has not woken.
+    app = http_app(inverter=INVERTER_ASLEEP)
+    app.query_http()
+
+    assert published(app)["datalogger_serial"] == "7A123208131058AB"
+    assert published(app)["wifi_ssid"] == "Airthings"
+
+
+def test_one_zero_among_real_values_is_still_a_reading(http_app):
+    # A wifi signal really can be 0. The response is only dead when every field the
+    # app reads from it is.
+    app = http_app(moniter=MONITER_NO_SIGNAL)
+    app.query_http()
+
+    assert published(app)["wifi_signal"] == "0"
+    assert published(app)["datalogger_serial"] == "7A123208131058AB"
+
+
+def test_a_zeroed_response_does_not_overwrite_what_was_published_before(http_app):
+    # The shape of the actual incident: a good read, then the datalogger comes back
+    # while the inverter is still asleep and the second read has to leave it alone.
+    app = http_app()
+    app.query_http()
+
+    app = http_app(inverter=INVERTER_ASLEEP)
+    app.query_http()
+
+    assert "inverter_firmware" not in published(app)


### PR DESCRIPTION
Closes #180

The datalogger is usually up before the inverter is. Its own page answers properly while `inverter.cgi` answers with nothing:

```
2026-08-18 21:37  Inverter Serial : 1805090232050086   Firmware : 83003A   Model : 509
2026-08-19 05:32  Inverter Serial : (dropped, empty)   Firmware : 000000   Model : 0
```

The empty serial was already dropped, so it kept the good value by luck. The other two aren't empty and nothing stopped them — and since `query_http` only runs when the datalogger comes back, they were still what Home Assistant was showing hours later.

**The rule.** This is the judgement `response_is_dead` already makes about a block of registers: a well formed answer in which everything reads as nothing is not a reading. Three deliberate limits on it:

- **Per endpoint.** `moniter.cgi` was answering correctly all that morning, and there's no reason to lose the wifi and datalogger sensors because the inverter hasn't woken.
- **Only the fields this app reads.** The rest of the body is described nowhere, and field 7 holds `NO` whether the inverter is awake or not — so the whole response can't be the test.
- **Every field, not any field.** A wifi signal really can be `0`. One zero among real values is still a reading.

**On the alternative I floated in the issue** — "never overwrite a stored identity value with a different one" — I didn't take it. It needs the code to know which sensors are identity fields and which are live measurements, because `wifi_signal` and `wifi_ip` legitimately change, and that distinction doesn't exist in `sensors.yaml` today. This rule needs no new metadata and matches what the modbus path already does.

**Tests** — `tests/test_http_asleep.py`. The awake capture is the real 2026-08-15 one; the asleep response is **reconstructed**, since the log records the three fields the app reads rather than the whole body, and the file says so. Two of the five fail on `main`.

128 passed, ruff clean.