### PR TITLE
fix(modbus): reconnect after a dead socket instead of killing the process

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,7 +4,6 @@ import yaml
 import logging
 import arrow
 import requests
-import os
 
 from typing import Any
 from config import AppConfig
@@ -842,13 +841,25 @@ class App:
                     count=count,
                 )
             except Exception as e:
-                # A broken pipe leaves the client talking to a socket that will never
-                # answer again, so let the container restart instead.
-                if str(e) == "[Errno 32] Broken pipe":
-                    logging.error("Broken pipe talking to the datalogger, restarting")
-                    os._exit(1)
-
+                # The socket cannot be trusted after this, and pymodbus will not
+                # notice: its connect() returns true whenever it still holds a socket
+                # object, without testing whether anything is at the other end. So a
+                # broken pipe left every later request writing into the same dead
+                # socket, which is why this used to kill the process and let the
+                # container restart.
+                #
+                # close() drops the socket, and the attempt after this one dials a
+                # new connection. The poll can then still succeed, where a restart
+                # lost it along with the in-memory half of the energy guards: the
+                # plausibility timestamps and the debounce counts are not in the
+                # retained topics load_state reads back.
+                #
+                # Only for a raised error. A response that says isError is the
+                # datalogger declining to answer, not a dead socket -- that is what
+                # it does every morning while the inverter wakes up, and reconnecting
+                # each time would be pure churn.
                 logging.error(f"Error occured while querying modbus: {e}")
+                client.close()
             else:
                 if not message.isError():
                     return message.registers

--- a/tests/test_modbus_read.py
+++ b/tests/test_modbus_read.py
@@ -31,12 +31,15 @@ class StubClient:
     def __init__(self, *answers):
         self.answers = list(answers)
         self.reads = []
+        self.closes = 0
         self.connected = True
 
     def connect(self):
+        self.connected = True
         return True
 
     def close(self):
+        self.closes += 1
         self.connected = False
 
     def read_input_registers(self, device_id, address, count):
@@ -221,3 +224,35 @@ def test_reads_that_start_working_again_clear_the_count(polls):
 
     assert app.retries_done == 0
     assert not app.datalogger_offline
+
+
+def test_a_broken_pipe_is_recovered_from_instead_of_killing_the_process(query):
+    # This used to be os._exit(1): kill the container and start again, losing the
+    # plausibility timestamps and the debounce counts with it. The path could not even
+    # be tested, because the exit would have taken the test runner down too.
+    app, client, registers = query(OSError("[Errno 32] Broken pipe"), live_response())
+
+    assert len(registers) == SPAN
+    assert len(client.reads) == 2, "retried, and the retry worked"
+
+
+def test_a_raised_error_drops_the_socket_so_the_next_attempt_redials(query):
+    # pymodbus connect() returns true whenever it still holds a socket object,
+    # without testing whether anything answers on it. Without the close, every later
+    # request goes into the same dead socket.
+    #
+    # A reset rather than a broken pipe, so this case can be run against the old
+    # behaviour. A broken pipe there called os._exit and would take the test runner
+    # with it, which is the other half of why that path was never covered.
+    app, client, registers = query(OSError("Connection reset by peer"), live_response())
+
+    assert client.closes == 2, "once for the dead socket, once at the end of the poll"
+
+
+def test_a_refused_read_does_not_drop_the_socket(query):
+    # An isError response is the datalogger declining to answer, which is what it
+    # does every morning while the inverter wakes up. The connection is fine, and
+    # reconnecting on each of those would be churn for nothing.
+    app, client, registers = query(Response(error=True), live_response())
+
+    assert client.closes == 1, "only the close at the end of the poll"


### PR DESCRIPTION
Closes #170

A broken pipe called `os._exit(1)` and left the container to restart. `load_state` reads the current day and pre-reset totals back from the retained topics, but the plausibility timestamps, debounce counts and settled values are in memory only — so a network hiccup reset the energy guards.

**pymodbus will not recover on its own**, and it's worth being precise about why:

```python
def connect(self):
    if self.socket:      # never tests whether anything is at the other end
        return True
```

`close()` is what sets `self.socket = None`. Until something calls it, every later request writes into the same dead socket — which is what made restarting look like the only way out.

**So the fix is better than the issue described.** Closing the socket means the next of the `CHUNK_ATTEMPTS` dials a fresh connection, so the poll can still succeed rather than being lost along with the guard state. Recovery happens *within* the poll, not on the next one.

**Deliberately narrow:** only on a raised exception. An `isError` response is the datalogger declining to answer, not a dead socket — that's what it does every morning while the inverter wakes, thirty times on 2026-08-19 with no exception raised at all. Reconnecting on each of those would be churn for nothing, so this change would have done nothing that morning, which is correct.

`import os` removed; that was its only use.

**On verification** — the recovery case can't be run against the old behaviour, because `os._exit` would take the test runner down too. That's the other half of why this path was never covered. The socket close is verified separately using a connection reset, which the old code didn't treat specially, and that test fails on `main`.

131 passed, ruff clean.