### PR TITLE
fix(modbus): read the register span, not whole chunks past the end of it

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -912,17 +912,31 @@ class App:
         chunk_size = self.config["datalogger"]["register_chunks"]
         expected_registers = 0
 
+        # register_span_end is the last register wanted, not one past it, so the range
+        # has to reach it. It did not, and a chunk size that happened to land exactly
+        # on the end silently lost that register: with the span 3004 to 3077 a
+        # register_chunks of 73 read 3004 to 3076 and stopped. The length check below
+        # passed, because 73 were asked for and 73 arrived, so the poll was kept and
+        # only the sensor needing the missing register failed -- as a KeyError caught
+        # up in main, logged once a poll, forever.
+        #
+        # The count is clamped for the same reason the range moved. Reading whole
+        # chunks past the end covered that bug by accident, six registers past 3077 at
+        # the default chunk size, and asking a datalogger this fragile for registers
+        # nothing is mapped to is not a habit worth keeping.
         for address in range(
-            self.register_span_start, self.register_span_end, chunk_size
+            self.register_span_start, self.register_span_end + 1, chunk_size
         ):
-            logging.info(f"Querying register {address} to {address + chunk_size}")
+            count = min(chunk_size, self.register_span_end - address + 1)
+
+            logging.info(f"Querying register {address} to {address + count - 1}")
 
             # Count each chunk once, not once per attempt. Counting per attempt
             # inflated the expected total to thousands and threw away five complete
             # 80 register responses on 2026-07-29 alone.
-            expected_registers += chunk_size
+            expected_registers += count
 
-            values = self.read_chunk(client, address, chunk_size)
+            values = self.read_chunk(client, address, count)
 
             if values is None:
                 # Nothing to gain from asking a datalogger that just refused three
@@ -938,9 +952,6 @@ class App:
             self.datalogger_is_offline(offline=False)
 
         client.close()
-
-        if client.connected:
-            logging.error("Client still connected to datalogger")
 
         # Sometimes we get a response with almost all values being 0, usually also multiple registers
         # are missing. In that case we just return an empty dictionary. This validation is not perfect

--- a/tests/test_modbus_read.py
+++ b/tests/test_modbus_read.py
@@ -13,7 +13,10 @@ import pytest
 
 import app as app_module
 
-SPAN = 80
+# The registers sensors.yaml actually asks for: 3004 to 3077 inclusive. This used to
+# be 80, the chunk size, because whole chunks were read whatever the span was.
+SPAN = 74
+FIRST, LAST = 3004, 3077
 
 
 class Response:
@@ -52,7 +55,7 @@ class StubClient:
         return answer
 
 
-def live_response(address=3004, count=SPAN):
+def live_response(address=FIRST, count=SPAN):
     # Register 3041 is the inverter temperature, the only thing that has to be non
     # zero for the response not to count as dead.
     return Response([250 if address + i == 3041 else 0 for i in range(count)])
@@ -256,3 +259,32 @@ def test_a_refused_read_does_not_drop_the_socket(query):
     app, client, registers = query(Response(error=True), live_response())
 
     assert client.closes == 1, "only the close at the end of the poll"
+
+
+def test_only_the_registers_that_are_wanted_are_asked_for(query):
+    # Whole chunks were read regardless of the span, so the default chunk size asked
+    # for six registers past the end of anything sensors.yaml maps.
+    app, client, registers = query(live_response())
+
+    assert client.reads == [(FIRST, SPAN)]
+    assert max(registers) == LAST
+
+
+def test_a_chunk_size_that_lands_on_the_end_still_reads_the_last_register(
+    make_app, clock, monkeypatch
+):
+    # The bug the range bound hid. With the span 3004 to 3077, a register_chunks of 73
+    # read 3004 to 3076 and stopped: the length check passed, because 73 were asked
+    # for and 73 arrived, so the poll was kept and only the sensor needing 3077
+    # failed, as a KeyError logged once a poll forever.
+    app = make_app(register_chunks=73)
+    app.get_register_interval()
+
+    client = StubClient(live_response(count=73), live_response(address=3077, count=1))
+    monkeypatch.setattr(app_module, "ModbusTcpClient", lambda *a, **kw: client)
+
+    registers = app.query_modbus()
+
+    assert client.reads == [(FIRST, 73), (LAST, 1)]
+    assert LAST in registers
+    assert len(registers) == SPAN


### PR DESCRIPTION
Refs #171 — two of the three items. See the bottom for the third.

**The over-read item was filed as cosmetic. It isn't.**

`register_span_end` is the last register wanted, not one past it, but the loop ran `range(start, span_end, chunk_size)`, which stops before it. Reading a whole chunk every time hid that, because the final chunk overshot the end and picked the register up anyway — and it only overshoots when the chunk size doesn't land exactly on the end.

With the span 3004–3077, `register_chunks: 73` read 3004 to 3076 and stopped:

```
chunk  covers 3077?  missing
   20  yes           []        (over-read 6)
   73  NO            [3077]    (over-read 0)
   80  yes           []        (over-read 6)
```

And nothing caught it. The length check compares what was asked for against what arrived — 73 of 73 — so the poll was kept. Only the sensor needing 3077 failed, as a `KeyError` caught up in `main`, logged once a poll, forever.

The range now reaches `span_end` and the count is clamped to what's left. Verified across every chunk size from 1 to 199: none misses a register, none reads one nothing is mapped to. Your `register_chunks: 80` now asks for 74 registers instead of 80.

**Also removed:** the check logging an error when `client.connected` was still true after `close()`. `connected` only reports whether a socket object exists, and `close()` has just set it to `None` — so it could never fire, and if it had, it wouldn't have meant what it says.

**Deliberately not included: the log volume item.** The issue proposed moving per-value lines to debug, which does nothing for you — the cluster runs with `debug: true`, as [I corrected on the issue](https://github.com/ahinko/tcpsolis2mqtt/issues/171#issuecomment-5333147044). Worth deciding whether it's a problem at all before acting; #171 stays open for that.

**Tests** — `SPAN` in `test_modbus_read.py` was 80, the chunk size, rather than the real span; it's now 74 with the span constants named. Two new cases, both fail on `main`, along with four existing ones whose data changed with the behaviour.

133 passed, ruff clean.