### PR TITLE
feat(logging): log both availability transitions, not just going offline

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -613,6 +613,13 @@ class App:
         if availability != self.availability_published:
             self.availability_published = availability
 
+            # The transition, both ways. Going offline was logged further down;
+            # coming back was not logged at all, so the only record of it was paho's
+            # own debug line for the publish. That made the one state change worth
+            # watching visible only to whoever had set debug on and knew to look for
+            # a client library's output, which is no way to audit a state machine.
+            logging.info(f"Datalogger {availability}")
+
             self.publish(
                 f"{self.config['mqtt']['topic_prefix']}/datalogger_availability",
                 availability,
@@ -620,7 +627,6 @@ class App:
             )
 
         if self.datalogger_offline:
-            logging.info("Datalogger offline")
             # Publish what is genuinely zero. Everything else is either covered by the
             # availability topic above or, for an energy counter, left alone.
             for sensor in self.sensors_config:

--- a/tests/test_offline_behaviour.py
+++ b/tests/test_offline_behaviour.py
@@ -199,3 +199,31 @@ def test_going_offline_still_publishes_what_is_genuinely_zero(offline):
     app = offline()
 
     assert published(app)["active_power"] == 0
+
+
+def test_both_availability_transitions_are_logged(make_app, caplog):
+    # Going offline was logged; coming back was not, so the only record of it was
+    # paho's debug line for the publish itself.
+    caplog.set_level("INFO")
+    app = make_app()
+    retries = app.config["datalogger"]["poll_retries"]
+
+    app.datalogger_is_offline(offline=False)
+
+    for _ in range(retries + 1):
+        app.datalogger_is_offline(offline=True)
+
+    messages = [record.message for record in caplog.records]
+
+    assert "Datalogger online" in messages
+    assert "Datalogger offline" in messages
+
+
+def test_a_transition_is_logged_once_not_every_poll(make_app, caplog):
+    caplog.set_level("INFO")
+    app = make_app()
+
+    for _ in range(5):
+        app.datalogger_is_offline(offline=False)
+
+    assert [r.message for r in caplog.records].count("Datalogger online") == 1


### PR DESCRIPTION
Refs #171 — this is what was left of the log volume item, and it goes the other way.

**The finding.** Going offline was logged. Coming back was not logged at all. The only record of the datalogger returning was paho's own debug line for the publish — which is how I ended up counting `Sending PUBLISH ... datalogger_availability` lines this morning to work out what had happened. That means the one state change worth watching was visible only to someone running with `debug: true` who knew to look for a client library's wire output.

Both directions now log at info, from the same branch that decides whether the retained message is worth sending — so the line appears exactly when the state changes, not on every poll that agrees with it.

**Why not the volume reduction the issue proposed.** Moving per-value lines to debug does nothing for you, since the cluster runs with `debug: true`. Cutting paho's output instead would have removed the evidence I actually used today. The real problem the volume complaint was pointing at is that the app wasn't saying enough on its own — so the fix is to log what matters, not to log less.

I'd leave the root logger alone. `pymodbus_apply_logging_config(logging.INFO)` shows the codebase already knows how to pin a library's level when it wants to, so if paho ever becomes a genuine nuisance the mechanism is there. 68 lines per poll is not a problem worth solving today.

**Tests** — both fail on `main`. One pins that each transition is logged; the other that it's logged once, not on every poll.

135 passed, ruff clean.