### PR TITLE
feat(modbus): let the connection be kept between polls, off by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,22 @@ read that table, so a new read type is an entry plus a decoder, and never a bran
 either of them. `app/sensors.py` decides which names `sensors.yaml` may use, and
 `tests/test_decode.py` fails if the two lists drift apart.
 
+### The modbus connection
+
+The client belongs to the app (`self.client`), not to a poll. `ensure_connected()` is
+the only thing that dials one and `drop_connection(reason)` the only thing that throws
+one away, which is what lets a read that raised redial mid-poll instead of writing
+into a dead socket. `release_connection()` at the end of a good poll is the single
+place the `datalogger.persistent_connection` setting is read.
+
+That setting is off by default and expected to be temporary. The stick accepts one
+connection at a time, so holding ours keeps everything else — Solis Cloud included —
+off it. Whether holding it even helps depends on whether this stick hangs up on an
+idle connection, which can only be measured: every connection logs one numbered line
+saying why the previous one ended, at info when the setting is on and debug when it is
+off. Once there are enough of those lines to decide, the setting and the losing branch
+both go, and that removal is the breaking change worth a 4.0.0.
+
 `VERSION` in `app/app.py` is hand-maintained and ships in the discovery payload as
 the device's `sw_version`. Bump it with a release.
 

--- a/app/app.py
+++ b/app/app.py
@@ -4,6 +4,7 @@ import yaml
 import logging
 import arrow
 import requests
+import socket
 
 from typing import Any, Callable, NamedTuple
 from config import AppConfig
@@ -42,6 +43,23 @@ CHUNK_RETRY_DELAY = 2
 # turn a poll that used to succeed into one that fails, and it wants measuring against
 # the hardware rather than guessing.
 MODBUS_TIMEOUT = 10
+
+# TCP keepalive for the connection to the datalogger: how long it may sit idle, then
+# how often to probe and how many unanswered probes declare the socket dead.
+#
+# Without these the kernel says nothing about a datalogger that vanished while we were
+# sleeping between polls. The socket still looks fine, so the loss surfaces only as
+# the next read timing out, CHUNK_ATTEMPTS times over -- most of a poll interval spent
+# discovering something that could have been known before the poll started. That is
+# what makes a kept connection worth having at all.
+#
+# 30 seconds idle plus three probes five seconds apart declares a dead peer inside 45,
+# which fits within the shortest poll interval anyone sets. The names are Linux's, and
+# the container is Alpine, but the tests run wherever the developer is: macOS spells
+# the idle option TCP_KEEPALIVE, so each option is applied only where it exists.
+KEEPALIVE_IDLE = 30
+KEEPALIVE_INTERVAL = 5
+KEEPALIVE_PROBES = 3
 
 # How many polls a finished period's total has to hold a new value before it is
 # believed. A rollover happens once a day at most and then persists, so a value that
@@ -127,6 +145,12 @@ class App:
 
         self.register_span_start = 0
         self.register_span_end = 0
+
+        # The connection is the app's, not the poll's. None means the next poll has to
+        # dial one, which is every poll unless datalogger.persistent_connection is on.
+        self.client = None
+        self.connections_opened = 0
+        self.connection_closed_reason = "nothing has been connected yet"
 
         self.last_accepted_value = {}
         self.current_day = None
@@ -864,9 +888,7 @@ class App:
         logging.info("Validation failed, every register in the response is zero")
         return True
 
-    def read_chunk(
-        self, client: ModbusTcpClient, address: int, count: int
-    ) -> list[int] | None:
+    def read_chunk(self, address: int, count: int) -> list[int] | None:
         # One chunk of registers, or None if the datalogger would not give it up.
         # Bounded attempts with a pause between them: the loop this replaces never
         # advanced and never slept, so a chunk that kept failing was retried as fast
@@ -875,48 +897,87 @@ class App:
         # for minutes, concentrated in the 05:30-05:45 window when the datalogger was
         # already struggling to stay up.
         for attempt in range(1, CHUNK_ATTEMPTS + 1):
-            try:
-                message = client.read_input_registers(
-                    device_id=self.config["datalogger"]["device_id"],
-                    address=address,
-                    count=count,
-                )
-            except Exception as e:
-                # The socket cannot be trusted after this, and pymodbus will not
-                # notice: its connect() returns true whenever it still holds a socket
-                # object, without testing whether anything is at the other end. So a
-                # broken pipe left every later request writing into the same dead
-                # socket, which is why this used to kill the process and let the
-                # container restart.
-                #
-                # close() drops the socket, and the attempt after this one dials a
-                # new connection. The poll can then still succeed, where a restart
-                # lost it along with the in-memory half of the energy guards: the
-                # plausibility timestamps and the debounce counts are not in the
-                # retained topics load_state reads back.
-                #
-                # Only for a raised error. A response that says isError is the
-                # datalogger declining to answer, not a dead socket -- that is what
-                # it does every morning while the inverter wakes up, and reconnecting
-                # each time would be pure churn.
-                logging.error(f"Error occured while querying modbus: {e}")
-                client.close()
-            else:
-                if not message.isError():
-                    return message.registers
+            # Per attempt, because an attempt can end by throwing the connection away.
+            # Cheap when there already is one: this hands back the client the app is
+            # holding, whether that was dialled a moment ago or three polls back.
+            client = self.ensure_connected()
 
-                logging.error(
-                    f"Could not read registers {address} to {address + count - 1} "
-                    f"on attempt {attempt}, might have lost connection"
-                )
+            if client is not None:
+                try:
+                    message = client.read_input_registers(
+                        device_id=self.config["datalogger"]["device_id"],
+                        address=address,
+                        count=count,
+                    )
+                except Exception as e:
+                    # The socket cannot be trusted after this, and pymodbus will not
+                    # notice: its connect() returns true whenever it still holds a
+                    # socket object, without testing whether anything is at the other
+                    # end. So a broken pipe left every later request writing into the
+                    # same dead socket, which is why this used to kill the process and
+                    # let the container restart.
+                    #
+                    # Dropping it means the attempt after this one dials a new
+                    # connection, and the poll can still succeed -- where a restart
+                    # lost the in-memory half of the energy guards with it: the
+                    # plausibility timestamps and the debounce counts are not in the
+                    # retained topics load_state reads back.
+                    #
+                    # Only for a raised error. A response that says isError is the
+                    # datalogger declining to answer, not a dead socket -- that is what
+                    # it does every morning while the inverter wakes up, and
+                    # reconnecting each time would be pure churn.
+                    logging.error(f"Error occured while querying modbus: {e}")
+                    self.drop_connection(f"a read raised {type(e).__name__}: {e}")
+                else:
+                    if not message.isError():
+                        return message.registers
+
+                    logging.error(
+                        f"Could not read registers {address} to {address + count - 1} "
+                        f"on attempt {attempt}, might have lost connection"
+                    )
 
             if attempt < CHUNK_ATTEMPTS:
                 sleep(CHUNK_RETRY_DELAY)
 
         return None
 
-    def connect_to_datalogger(self) -> ModbusTcpClient | None:
-        # A connected client, or None with the datalogger already told it is offline.
+    def keepalive_options(self) -> list[tuple[int, int, int]]:
+        # setsockopt arguments for this platform, skipping what it does not have.
+        options = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+        for name, value in (
+            # Linux, then the macOS spelling of the same option.
+            (("TCP_KEEPIDLE", "TCP_KEEPALIVE"), KEEPALIVE_IDLE),
+            (("TCP_KEEPINTVL",), KEEPALIVE_INTERVAL),
+            (("TCP_KEEPCNT",), KEEPALIVE_PROBES),
+        ):
+            option = next(
+                (getattr(socket, n) for n in name if hasattr(socket, n)), None
+            )
+
+            if option is not None:
+                options.append((socket.IPPROTO_TCP, option, value))
+
+        return options
+
+    def enable_keepalive(self, client: ModbusTcpClient) -> None:
+        # On every connection, not only the ones that are kept: a poll can outlive its
+        # own socket -- CHUNK_ATTEMPTS reads at MODBUS_TIMEOUT each is 30 seconds of
+        # one -- and nothing here is worth a branch to avoid.
+        if client.socket is None:
+            return
+
+        try:
+            for level, option, value in self.keepalive_options():
+                client.socket.setsockopt(level, option, value)
+        except OSError as e:
+            # Not fatal. Keepalive makes a vanished datalogger surface sooner; without
+            # it the read timeouts still find out, just slower.
+            logging.warning(f"Could not set TCP keepalive on the connection: {e}")
+
+    def dial_datalogger(self) -> ModbusTcpClient | None:
         try:
             client = ModbusTcpClient(
                 self.config["datalogger"]["host"],
@@ -931,9 +992,9 @@ class App:
 
         except Exception as e:
             logging.error(f"Unable to connect to datalogger: {e}")
-            if not self.datalogger_offline:
-                self.datalogger_is_offline(offline=True)
             return None
+
+        self.enable_keepalive(client)
 
         # A connection that opens says nothing about whether there is a working
         # datalogger behind it, so nothing is declared here. Every morning while the
@@ -946,10 +1007,79 @@ class App:
         # Assistant holding the voltages and the frequency from before it started.
         #
         # The first chunk of registers that actually arrives is what says we are
-        # online, in read_span below.
+        # online, in read_span below. Keeping a connection makes that the only way it
+        # can be said, since a reused connection does no handshake to be fooled by.
         return client
 
-    def read_span(self, client: ModbusTcpClient) -> tuple[dict[int, int], int]:
+    def ensure_connected(self) -> ModbusTcpClient | None:
+        # The connection the app is holding, dialling one first if it has none. None
+        # means the datalogger did not answer the dial; the caller decides what a poll
+        # makes of that, so that a failed poll is counted once however many attempts
+        # it was made of.
+        if self.client is not None:
+            # connected only reports whether the client is still holding a socket
+            # object, which is exactly the question here. When the datalogger hangs up
+            # mid-read pymodbus closes its own socket, and its next request then dials
+            # a new one out of sight: no line in the log, and no chance to set
+            # keepalive on the socket that replaced it. Counting reconnects is the
+            # whole reason the setting exists, so they are made here or not at all.
+            if self.client.connected:
+                return self.client
+
+            self.drop_connection("pymodbus had already closed the socket")
+
+        reason = self.connection_closed_reason
+        client = self.dial_datalogger()
+
+        if client is None:
+            return None
+
+        self.client = client
+        self.connections_opened += 1
+
+        # "The setting is on" and "the connection is actually surviving" look the same
+        # in the logs otherwise, and this line is how the question the setting exists
+        # to ask gets answered: these sticks are widely reported to hang up on an idle
+        # connection after a minute or two, which at a 30 second poll interval would
+        # mean reconnecting nearly every poll and gaining nothing. Leave it on for a
+        # day and count these.
+        message = (
+            f"Connected to datalogger, connection {self.connections_opened} since "
+            f"startup, previous one ended because {reason}"
+        )
+
+        if self.config["datalogger"]["persistent_connection"]:
+            logging.info(message)
+        else:
+            # A connection per poll is the whole design in this mode, so it is not
+            # news, and at a 30 second interval it would be 2880 lines a day.
+            logging.debug(message)
+
+        return self.client
+
+    def drop_connection(self, reason: str) -> None:
+        # Throw the connection away, with why on record for the line the next dial
+        # logs. Safe to call when there is nothing to drop, which is what makes it
+        # usable as "make sure there is no connection" as well.
+        self.connection_closed_reason = reason
+
+        if self.client is None:
+            return
+
+        self.client.close()
+        self.client = None
+
+    def release_connection(self) -> None:
+        # End of a poll that worked. Holding on to the connection is the entire point
+        # of the setting; hanging up is what this app has always done, and what leaves
+        # the datalogger free for whatever else wants to talk to it -- it accepts one
+        # connection at a time.
+        if self.config["datalogger"]["persistent_connection"]:
+            return
+
+        self.drop_connection("the connection is not kept between polls")
+
+    def read_span(self) -> tuple[dict[int, int], int]:
         # The whole register span, chunk by chunk, with the number of registers that
         # were asked for. The two together are what the caller judges the poll on: a
         # short answer is a failed poll, however well formed each chunk was.
@@ -981,7 +1111,7 @@ class App:
             # 80 register responses on 2026-07-29 alone.
             expected_registers += count
 
-            values = self.read_chunk(client, address, count)
+            values = self.read_chunk(address, count)
 
             if values is None:
                 # Nothing to gain from asking a datalogger that just refused three
@@ -1001,14 +1131,15 @@ class App:
     def query_modbus(self) -> dict[int, int]:
         logging.info("Querying modbus")
 
-        client = self.connect_to_datalogger()
-
-        if client is None:
+        if self.ensure_connected() is None:
+            # Nothing answered, so there is nothing to read. One failed poll, counted
+            # once: read_chunk may dial again within this poll, and every one of those
+            # attempts failing is still the same single failure to the retry budget.
+            if not self.datalogger_offline:
+                self.datalogger_is_offline(offline=True)
             return {}
 
-        registers, expected_registers = self.read_span(client)
-
-        client.close()
+        registers, expected_registers = self.read_span()
 
         # Sometimes we get a response with almost all values being 0, usually also multiple registers
         # are missing. In that case we just return an empty dictionary. This validation is not perfect
@@ -1018,7 +1149,14 @@ class App:
                 f"Validation of number of queried registers failed. "
                 f"Queried: {expected_registers}, received: {len(registers)}"
             )
+            # A poll that could not read the span it asked for leaves a connection
+            # there is no reason to trust, so the next poll starts from a fresh one.
+            # That is also what every poll did before a connection could be kept, so
+            # turning the setting on cannot make a bad morning worse than it was.
+            self.drop_connection("the register span could not be read in full")
             return {}
+
+        self.release_connection()
 
         if self.response_is_dead(registers):
             return {}

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,17 @@ class DataLoggerConfig(Schema):
     poll_interval_if_off = fields.Int(required=False, load_default=600)
     poll_retries = fields.Int(required=False, load_default=10)
     register_chunks = fields.Int(required=False, load_default=80)
+    # Keep the modbus connection open between polls instead of dialling a new one
+    # every time. Off by default, and deliberately so: this datalogger accepts one
+    # connection at a time, so holding it means nothing else -- Solis Cloud included
+    # -- can talk to the stick, where closing it leaves a gap in every poll cycle.
+    #
+    # Expected to be temporary. These sticks are widely reported to close an idle
+    # connection themselves after a minute or two, which at a 30 second poll interval
+    # would mean reconnecting nearly every poll and gaining nothing. The reconnect
+    # counts this logs are how that gets measured; once it is measured, one of the two
+    # behaviours goes and this setting goes with it.
+    persistent_connection = fields.Bool(required=False, load_default=False)
     http = fields.Nested(HttpConfig(), required=False)
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,6 +8,11 @@ datalogger:
   poll_interval_if_off: 600
   poll_retries: 10
   register_chunks: 20
+  # Keep the modbus connection open between polls instead of dialling a new one every
+  # poll. The datalogger accepts one connection at a time, so with this on nothing
+  # else can reach it -- including Solis Cloud. Leave it off unless you are measuring
+  # what it does; the app logs a line for every connection it opens.
+  persistent_connection: False
   http:
     enabled: True
     user: admin

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Because it works! If I for some reason would stop using this myself then I will 
 
 ### Does Solis Cloud still work?
 
-Most other integrations that I found all stated that Solis Cloud would not work when polling the data logger over MODBUS. In my brief and short testing Solid Cloud still works, but not perfectly. My guess is that most other integrations keeps the connection with the data logger alive while this project closes the connection when its done and then reconnects when it's time for the next update. By "not perfectly" I mean that I can see that Solis Cloud is not always updated every 5 minutes. Sometimes it takes 15-20 minutes between updates but I've always seen that the data logger sooner or later are able to send data to Solis Cloud. And if I stop the script/Docker container I always seen an update in Solid cloud within 10 minutes without having to restart the data logger.
+Most other integrations that I found all stated that Solis Cloud would not work when polling the data logger over MODBUS. In my brief and short testing Solid Cloud still works, but not perfectly. My guess is that most other integrations keeps the connection with the data logger alive while this project closes the connection when its done and then reconnects when it's time for the next update. That is still the default, and `datalogger.persistent_connection` is the setting that changes it — see [Keeping the connection open](#keeping-the-connection-open). By "not perfectly" I mean that I can see that Solis Cloud is not always updated every 5 minutes. Sometimes it takes 15-20 minutes between updates but I've always seen that the data logger sooner or later are able to send data to Solis Cloud. And if I stop the script/Docker container I always seen an update in Solid cloud within 10 minutes without having to restart the data logger.
 
 ### Is it possible to control the inverter?
 
@@ -61,6 +61,28 @@ Maybe, I have no plans for it at the moment. My main goal is to get the data int
 
 ## Getting started
 Prepare a config file. Use `config.example.yaml` and modify it to your needs and save it as `config.yaml`. Most values should be self-explanatory. `register_chunks` is set to 20 by default but during my testing I've been able to query my datalogger for more than 80 registers at the same time.
+
+### Keeping the connection open
+By default the app dials a connection to the data logger, reads, and hangs up again on every poll. For MODBUS TCP that's the unusual choice — one connection held open is the normal one — and `datalogger.persistent_connection: True` does that instead:
+
+```yaml
+datalogger:
+  persistent_connection: True
+```
+
+It's off by default because it's a trade, not an improvement. The data logger accepts **one connection at a time**, so while this app holds it, nothing else can talk to the stick — Solis Cloud included. Hanging up after each poll leaves a gap in every cycle where something else can get in.
+
+Whether it's worth the trade is a question about your stick, not about this app: these WiFi sticks are widely reported to close an idle connection themselves after a minute or two, and at a 30 second poll interval that would mean reconnecting nearly every poll and gaining nothing. So the app logs a line for every connection it opens, numbered and saying why the previous one ended:
+
+```
+Connected to datalogger, connection 12 since startup, previous one ended because a read raised OSError: Connection reset by peer
+```
+
+Turn the setting on, leave it a day, and count those lines. One or two means the connection is surviving. One per poll means the stick is hanging up and the setting is buying nothing.
+
+Either way the app sets TCP keepalive on the socket, so a data logger that vanishes while the app is sleeping is noticed by the kernel within about 45 seconds instead of by the next read timing out three times over.
+
+Expect this setting to go away once there are enough measurements to pick a winner. Whichever behaviour loses will be removed along with it.
 
 ### Upgrading to 3.0
 **`inverter.max_power_kw` is now required and the container won't start without it.** Set it to the nameplate rating of your inverter, in kW:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,90 @@ def total_power(sensors_config):
     return next(s for s in sensors_config if s["name"] == "total_power")
 
 
+# The registers sensors.yaml actually asks for: 3004 to 3077 inclusive.
+SPAN = 74
+FIRST, LAST = 3004, 3077
+
+
+class Response:
+    def __init__(self, registers=None, error=False):
+        self.registers = registers or []
+        self.error = error
+
+    def isError(self):
+        return self.error
+
+
+class FakeSocket:
+    """Records the socket options the app sets, and can refuse them."""
+
+    def __init__(self, refuse=False):
+        self.options = []
+        self.refuse = refuse
+
+    def setsockopt(self, level, option, value):
+        if self.refuse:
+            raise OSError("Protocol not available")
+
+        self.options.append((level, option, value))
+
+
+class StubClient:
+    """A datalogger that answers with whatever the test queued up.
+
+    One object stands in for every client the app builds, so that dialling again
+    shows up as another connect() rather than as another object.
+    """
+
+    def __init__(
+        self, *answers, refuse_socket_options=False, hangs_up_after_read=False
+    ):
+        self.answers = list(answers)
+        self.reads = []
+        self.closes = 0
+        self.connects = 0
+        self.connected = False
+        self.socket = None
+        # Every socket this client has had, since close() drops the current one and a
+        # test still wants to see what was set on it.
+        self.sockets = []
+        self.refuse_socket_options = refuse_socket_options
+        # The datalogger hanging up on its own: pymodbus closes its socket when the
+        # peer goes away mid-read and says nothing if the answer arrived first.
+        self.hangs_up_after_read = hangs_up_after_read
+
+    def connect(self):
+        self.connects += 1
+        self.connected = True
+        self.socket = FakeSocket(refuse=self.refuse_socket_options)
+        self.sockets.append(self.socket)
+        return True
+
+    def close(self):
+        self.closes += 1
+        self.connected = False
+        self.socket = None
+
+    def read_input_registers(self, device_id, address, count):
+        self.reads.append((address, count))
+        answer = self.answers.pop(0) if self.answers else Response(error=True)
+
+        if isinstance(answer, Exception):
+            raise answer
+
+        if self.hangs_up_after_read:
+            self.connected = False
+            self.socket = None
+
+        return answer
+
+
+def live_response(address=FIRST, count=SPAN):
+    # Register 3041 is the inverter temperature, the only thing that has to be non
+    # zero for the response not to count as dead.
+    return Response([250 if address + i == 3041 else 0 for i in range(count)])
+
+
 class Clock:
     """Stand in for time.monotonic so tests can span days in an instant."""
 
@@ -64,7 +148,13 @@ def make_app(sensors_config):
     assertions look at.
     """
 
-    def _make(day="2026-07-28", max_power_kw=15, poll_retries=3, register_chunks=80):
+    def _make(
+        day="2026-07-28",
+        max_power_kw=15,
+        poll_retries=3,
+        register_chunks=80,
+        persistent_connection=False,
+    ):
         app = App.__new__(App)
         app.config = {
             "mqtt": {"enabled": False, "topic_prefix": "tcpsolis2mqtt"},
@@ -77,6 +167,7 @@ def make_app(sensors_config):
                 "poll_interval_if_off": 600,
                 "poll_retries": poll_retries,
                 "register_chunks": register_chunks,
+                "persistent_connection": persistent_connection,
                 "http": {"enabled": False},
             },
         }
@@ -95,6 +186,10 @@ def make_app(sensors_config):
         app.register_span_start = 0
         app.register_span_end = 0
 
+        app.client = None
+        app.connections_opened = 0
+        app.connection_closed_reason = "nothing has been connected yet"
+
         app.day = day
         app.local_date = lambda: app.day
 
@@ -106,3 +201,46 @@ def make_app(sensors_config):
         return app
 
     return _make
+
+
+@pytest.fixture
+def query(make_app, clock, monkeypatch):
+    """Run one poll against a stub datalogger and return what it produced."""
+
+    def _query(*answers, client=None, **config):
+        client = client or StubClient(*answers)
+        app = make_app(**config)
+        app.get_register_interval()
+
+        def build(*args, **kwargs):
+            app.client_kwargs = kwargs
+            return client
+
+        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
+        return app, client, app.query_modbus()
+
+    return _query
+
+
+@pytest.fixture
+def polls(make_app, clock, monkeypatch):
+    """One App polled repeatedly, so state that carries between polls is visible."""
+
+    def _polls(*rounds, client=None, **config):
+        app = make_app(**config)
+        app.get_register_interval()
+        client = client or StubClient()
+        app.stub_client = client
+
+        def build(*args, **kwargs):
+            return client
+
+        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
+
+        for answers in rounds:
+            client.answers = list(answers)
+            app.query_modbus()
+
+        return app
+
+    return _polls

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,28 @@ def test_a_fractional_rating_is_kept():
     )
 
 
+def test_the_connection_is_not_kept_unless_it_is_asked_for():
+    # The datalogger accepts one connection at a time, so holding ours keeps
+    # everything else -- Solis Cloud included -- off the stick. Anyone who wants that
+    # trade has to say so.
+    assert AppConfig().load(config())["datalogger"]["persistent_connection"] is False
+
+
+def test_the_connection_can_be_kept():
+    kept = config()
+    kept["datalogger"]["persistent_connection"] = True
+
+    assert AppConfig().load(kept)["datalogger"]["persistent_connection"] is True
+
+
+def test_the_shipped_example_leaves_the_connection_per_poll_behaviour_alone():
+    import yaml
+
+    example = yaml.safe_load(open("config.example.yaml"))
+
+    assert not example["datalogger"].get("persistent_connection")
+
+
 def test_the_shipped_example_names_a_rating():
     import yaml
 

--- a/tests/test_modbus_read.py
+++ b/tests/test_modbus_read.py
@@ -9,98 +9,12 @@ complete 80 register responses discarded on top of that, because the expected
 register count was incremented once per attempt rather than once per chunk.
 """
 
-import pytest
-
 import app as app_module
 
-# The registers sensors.yaml actually asks for: 3004 to 3077 inclusive. This used to
-# be 80, the chunk size, because whole chunks were read whatever the span was.
-SPAN = 74
-FIRST, LAST = 3004, 3077
-
-
-class Response:
-    def __init__(self, registers=None, error=False):
-        self.registers = registers or []
-        self.error = error
-
-    def isError(self):
-        return self.error
-
-
-class StubClient:
-    """A datalogger that answers with whatever the test queued up."""
-
-    def __init__(self, *answers):
-        self.answers = list(answers)
-        self.reads = []
-        self.closes = 0
-        self.connected = True
-
-    def connect(self):
-        self.connected = True
-        return True
-
-    def close(self):
-        self.closes += 1
-        self.connected = False
-
-    def read_input_registers(self, device_id, address, count):
-        self.reads.append((address, count))
-        answer = self.answers.pop(0) if self.answers else Response(error=True)
-
-        if isinstance(answer, Exception):
-            raise answer
-
-        return answer
-
-
-def live_response(address=FIRST, count=SPAN):
-    # Register 3041 is the inverter temperature, the only thing that has to be non
-    # zero for the response not to count as dead.
-    return Response([250 if address + i == 3041 else 0 for i in range(count)])
-
-
-@pytest.fixture
-def query(make_app, clock, monkeypatch):
-    """Run one poll against a stub datalogger and return what it produced."""
-
-    def _query(*answers):
-        client = StubClient(*answers)
-        app = make_app()
-        app.get_register_interval()
-
-        def build(*args, **kwargs):
-            app.client_kwargs = kwargs
-            return client
-
-        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
-        return app, client, app.query_modbus()
-
-    return _query
-
-
-@pytest.fixture
-def polls(make_app, clock, monkeypatch):
-    """One App polled repeatedly, so state that carries between polls is visible."""
-
-    def _polls(*rounds):
-        app = make_app()
-        app.get_register_interval()
-        client = StubClient()
-
-        def build(*args, **kwargs):
-            return client
-
-        monkeypatch.setattr(app_module, "ModbusTcpClient", build)
-
-        for answers in rounds:
-            client.answers = list(answers)
-            app.query_modbus()
-
-        return app
-
-    return _polls
+# The stub datalogger, the register span and the query/polls fixtures live in
+# conftest.py, because the connection lifetime tests in test_persistent_connection.py
+# poll the same stub.
+from conftest import FIRST, LAST, SPAN, Response, StubClient, live_response
 
 
 def test_a_chunk_is_read_once_when_it_answers(query):

--- a/tests/test_persistent_connection.py
+++ b/tests/test_persistent_connection.py
@@ -1,0 +1,206 @@
+"""How long the connection to the datalogger lives, and what the socket is told.
+
+For modbus TCP, dialling a fresh connection for every read is the unusual choice; one
+connection held open is the normal one. This datalogger makes that a trade rather than
+an improvement: it accepts a single connection at a time, so holding ours means
+nothing else -- Solis Cloud included -- can reach the stick, where hanging up leaves a
+gap in every poll cycle where something else can. Hence the setting, and hence off by
+default.
+
+The setting is expected to be temporary. These sticks are widely reported to hang up
+on an idle connection after a minute or two, and at a 30 second poll interval that
+would mean reconnecting nearly every poll and gaining nothing. That cannot be settled
+from here, only measured, which is what the one log line per connection is for: turn
+it on, leave it a day, count them.
+"""
+
+import socket
+
+from app import KEEPALIVE_IDLE, KEEPALIVE_INTERVAL, KEEPALIVE_PROBES
+from conftest import SPAN, StubClient, live_response
+
+KEPT = {"persistent_connection": True}
+
+
+def connection_lines(caplog):
+    return [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("Connected to datalogger")
+    ]
+
+
+def test_the_connection_is_dropped_after_every_poll_by_default(polls):
+    app = polls((live_response(),), (live_response(),))
+
+    assert app.stub_client.connects == 2
+    assert app.stub_client.closes == 2
+    assert app.client is None
+
+
+def test_the_connection_is_kept_between_polls_when_it_is_asked_for(polls):
+    app = polls((live_response(),), (live_response(),), (live_response(),), **KEPT)
+
+    assert app.stub_client.connects == 1, "dialled once, then reused"
+    assert app.stub_client.closes == 0
+    assert app.client is app.stub_client
+
+
+def test_a_kept_connection_still_reads_the_whole_span_every_poll(polls):
+    app = polls((live_response(),), (live_response(),), **KEPT)
+
+    assert app.stub_client.reads == [(3004, SPAN), (3004, SPAN)]
+
+
+def test_a_poll_that_could_not_read_the_span_lets_the_connection_go(polls):
+    # A connection the datalogger would not answer over is not one to hold on to, and
+    # holding it would keep everything else off the stick for nothing. This is also
+    # what every poll did before the connection could be kept, so turning the setting
+    # on cannot make a bad morning worse than it already was.
+    app = polls((), **KEPT)
+
+    assert app.client is None
+    assert app.stub_client.closes == 1
+
+
+def test_the_poll_after_a_failure_dials_a_fresh_connection(polls):
+    app = polls((live_response(),), (), (live_response(),), **KEPT)
+
+    assert app.stub_client.connects == 2
+    assert app.client is app.stub_client
+
+
+def test_a_dead_socket_is_redialled_inside_the_poll(query):
+    # The raised error drops the connection, and the attempt after it dials again
+    # rather than writing into the same dead socket. With the connection kept, that
+    # redial is the app's own rather than something pymodbus does out of sight.
+    app, client, registers = query(
+        OSError("Connection reset by peer"), live_response(), **KEPT
+    )
+
+    assert client.connects == 2
+    assert len(registers) == SPAN
+
+
+def test_a_reused_connection_is_not_evidence_the_datalogger_is_there(polls):
+    # There is no handshake to be fooled by when the connection is reused, so the
+    # first chunk of registers that arrives is the only thing that can say "online".
+    # A poll whose reads are all refused has to count against the retry budget the
+    # same as any other, or the datalogger is never declared offline at all.
+    app = polls((live_response(),), (), **KEPT)
+
+    assert app.retries_done == 1
+
+
+def hangs_up_after_every_poll():
+    # The failure mode this setting is most likely to meet. These sticks are reported
+    # to drop an idle connection, and pymodbus answers that by closing its own socket
+    # and dialling a new one on the next request -- silently, so the reconnects the
+    # setting exists to count would never appear, and the new socket would carry none
+    # of the keepalive this app sets.
+    return StubClient(hangs_up_after_read=True)
+
+
+def test_a_datalogger_that_hung_up_is_redialled_rather_than_reused(polls):
+    app = polls(
+        (live_response(),),
+        (live_response(),),
+        client=hangs_up_after_every_poll(),
+        **KEPT,
+    )
+
+    assert app.stub_client.connects == 2
+    assert app.stub_client.sockets[1].options == app.keepalive_options()
+
+
+def test_a_connection_pymodbus_had_already_closed_says_so(polls, caplog):
+    caplog.set_level("INFO")
+
+    polls(
+        (live_response(),),
+        (live_response(),),
+        client=hangs_up_after_every_poll(),
+        **KEPT,
+    )
+
+    assert "pymodbus had already closed the socket" in connection_lines(caplog)[1]
+
+
+def test_every_connection_is_logged_with_why_the_last_one_ended(polls, caplog):
+    caplog.set_level("INFO")
+
+    polls((live_response(),), (), (live_response(),), **KEPT)
+
+    first, second = connection_lines(caplog)
+
+    assert "connection 1 since startup" in first
+    assert "nothing has been connected yet" in first
+    assert "connection 2 since startup" in second
+    assert "the register span could not be read in full" in second
+
+
+def test_a_lost_socket_says_so_in_the_line_for_the_connection_after_it(query, caplog):
+    caplog.set_level("INFO")
+
+    query(OSError("Connection reset by peer"), live_response(), **KEPT)
+
+    assert (
+        "a read raised OSError: Connection reset by peer" in connection_lines(caplog)[1]
+    )
+
+
+def test_a_connection_per_poll_is_not_worth_a_line_a_poll(polls, caplog):
+    # The default mode dials every poll by design, so at a 30 second interval this
+    # would be 2880 lines a day saying only that the app is working as configured.
+    caplog.set_level("INFO")
+
+    polls((live_response(),), (live_response(),))
+
+    assert connection_lines(caplog) == []
+
+
+def test_the_connections_are_still_there_at_debug(polls, caplog):
+    caplog.set_level("DEBUG")
+
+    polls((live_response(),), (live_response(),))
+
+    assert len(connection_lines(caplog)) == 2
+
+
+def test_keepalive_is_switched_on(make_app):
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in make_app().keepalive_options()
+
+
+def test_the_kernel_is_told_how_long_to_wait_and_how_often_to_probe(make_app):
+    # Without these, a datalogger that vanished while we slept is only discovered by
+    # the next read timing out, three times over -- most of a poll interval spent
+    # finding out something the kernel could have established during the sleep.
+    values = [value for _, _, value in make_app().keepalive_options()]
+
+    assert values == [1, KEEPALIVE_IDLE, KEEPALIVE_INTERVAL, KEEPALIVE_PROBES]
+
+
+def test_every_declared_option_reaches_the_socket(query):
+    app, client, _ = query(live_response())
+
+    assert client.sockets[0].options == app.keepalive_options()
+
+
+def test_a_redialled_connection_gets_its_own_keepalive(query):
+    # A new socket starts with the system defaults, which on Linux is a first probe
+    # after two hours.
+    app, client, registers = query(OSError("Connection reset by peer"), live_response())
+
+    assert client.sockets[1].options == app.keepalive_options()
+
+
+def test_a_socket_that_refuses_the_options_still_gets_polled(query, caplog):
+    # Keepalive makes a vanished datalogger surface sooner. Without it the read
+    # timeouts still find out, just slower, which is not worth failing a poll over.
+    caplog.set_level("WARNING")
+    client = StubClient(live_response(), refuse_socket_options=True)
+
+    app, client, registers = query(client=client)
+
+    assert len(registers) == SPAN
+    assert "Could not set TCP keepalive" in caplog.records[0].message


### PR DESCRIPTION
Closes #172.

Adds `datalogger.persistent_connection`, **off by default**, which keeps the modbus connection open between polls instead of dialling a new one every time.

## Why off by default

The datalogger accepts one connection at a time, so holding ours keeps everything else — Solis Cloud included — off the stick. Hanging up after each poll leaves a gap in every cycle where something else can get in. That is a trade, not an improvement, so it has to be asked for.

## The client is now the app's, not the poll's

| method | job |
| --- | --- |
| `ensure_connected()` | the only thing that dials; hands back the held connection otherwise |
| `drop_connection(reason)` | the only thing that throws one away, recording why |
| `release_connection()` | end of a good poll — the single place the setting is read |
| `enable_keepalive()` / `keepalive_options()` | `SO_KEEPALIVE`, 30s idle, 5s probes, 3 probes |

* `read_chunk` takes the client per attempt, so a read that raised drops the connection and the next attempt dials a fresh one — the redial is the app's now, not one pymodbus does out of sight.
* A poll that could not read the whole span drops the connection, so the next poll starts fresh. Every poll did that before, so turning the setting on cannot make a bad morning worse than it already was.
* `ensure_connected` checks whether the client still holds a socket before reusing it. This matters more than it looks: pymodbus's `_handle_abrupt_socket_close` closes its own socket when the peer hangs up mid-read, and its next request dials again silently — which is exactly the idle-hangup case being measured. It would have counted as zero reconnects, on a socket carrying none of the keepalive.

## TCP keepalive

On every connection, kept or not. 30 seconds idle plus three probes five seconds apart means a datalogger that vanished while the app slept is declared dead by the kernel inside 45 seconds, instead of by the next read timing out `CHUNK_ATTEMPTS` times over. The option names are Linux's and the container is Alpine, but the tests run on macOS, so each option is applied only where the platform has it.

## One line per connection

Info when the setting is on, debug when it is off — 2880 lines a day otherwise, saying only that the app is working as configured.

```
Connected to datalogger, connection 3 since startup, previous one ended because a read raised OSError: Connection reset by peer
```

This is the point of shipping the setting at all. These sticks are widely reported to hang up on an idle connection after a minute or two; at a 30 second poll interval that would mean reconnecting nearly every poll and gaining nothing. It cannot be settled from here, only measured: turn it on, leave it a day, count the lines. Then the setting and the losing branch both go, and that removal is the breaking change worth a 4.0.0.

## The behaviour change #172 flagged

None needed. #181 already moved the online transition off the handshake and onto the first chunk of registers that arrives — which is the only thing a reused connection could have said it from anyway. A poll whose reads are all refused still counts against the retry budget, kept connection or not, and `test_a_reused_connection_is_not_evidence_the_datalogger_is_there` pins that.

## Tests

New `tests/test_persistent_connection.py` — connection lifetime both ways, drop on a failed poll, mid-poll redial, the silent-hangup case, the log lines, and keepalive (including a socket that refuses the options). The stub datalogger and the `query`/`polls` fixtures moved to `conftest.py` so both test files poll the same stub; `test_modbus_read.py` imports them and is otherwise untouched.

174 passed; `ruff format --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BizgAhMgYcmMXjHFX7pbbs